### PR TITLE
Use Jinja2 as newer template engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ C implementation of Open Neural Network Exchange Runtime
 
 # Requirements
  * python3         # to run examples and test cases
+ * python3-jinja2  # To render templates
  * cmake >= 3.1
  * ninja-build
 

--- a/src/opset/Exp.c
+++ b/src/opset/Exp.c
@@ -31,9 +31,9 @@ int Exp(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
-        {% set exp_func = 'expf' if DTYPE == FLOAT32 else 'exp' %}
-    case {{DTYPE}}: {
+        // {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
+        // {% set exp_func = 'expf' if DTYPE == FLOAT32 else 'exp' %}
+    case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
 
@@ -42,7 +42,7 @@ int Exp(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
         }
         break;
     }
-        {% endfor %}
+        // {% endfor %}
     default:
         connx_error("Exp: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Exp.c
+++ b/src/opset/Exp.c
@@ -31,25 +31,18 @@ int Exp(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        TEMPLATE_START(FLOAT32, FLOAT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-    case TEMPLATE_DTYPE: {
-        TEMPLATE_TYPE* X_array = X->buffer;
-        TEMPLATE_TYPE* Y_array = Y->buffer;
+        {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
+        {% set exp_func = 'expf' if DTYPE == FLOAT32 else 'exp' %}
+    case {{DTYPE}}: {
+        {{TYPE}}* X_array = X->buffer;
+        {{TYPE}}* Y_array = Y->buffer;
 
         for (int32_t i = 0; i < total; i++) {
-#if TEMPLATE_DTYPE == FLOAT32
-            Y_array[i] = expf(X_array[i]);
-#else
-            Y_array[i] = exp(X_array[i]);
-#endif // TEMPLATE_DTYPE == FLOAT32
+            Y_array[i] = {{exp_func}}(X_array[i]);
         }
         break;
     }
-        TEMPLATE_END()
+        {% endfor %}
     default:
         connx_error("Exp: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;


### PR DESCRIPTION
# Pitch

Current template engine(`#TEMPLATE_START`) has these problems.

## Easy to mistake with C preprocessors

On [this commit][pr-20], has a bug with preprocessors and pass the code review.

[pr-20]: https://github.com/semihlab/connx/commit/f91a0242c1708ffb6852fe6faa03189ff530329e#diff-89c7bde9b4354f0d0f2626c7dc06a603dcb993648579aed0a687e780441dd91dR34-R52

```c
    switch (X->dtype) {
        TEMPLATE_START(FLOAT32, FLOAT64)
#undef TEMPLATE_DTYPE
#undef TEMPLATE_TYPE
#define TEMPLATE_DTYPE FLOAT32
#define TEMPLATE_TYPE float32_t
    case TEMPLATE_DTYPE: {
        TEMPLATE_TYPE* X_array = X->buffer;
        TEMPLATE_TYPE* Y_array = Y->buffer;

        for (int32_t i = 0; i < total; i++) {
#if TEMPLATE_DTYPE == FLOAT32
            Y_array[i] = expf(X_array[i]);
#else
            Y_array[i] = exp(X_array[i]);
#endif // TEMPLATE_DTYPE == FLOAT32
        }
        break;
    }
        TEMPLATE_END()
```

## multiple templates cannot be nested

`TEMPLATE_START` uses constant varname `TEMPLATE_DTYPE` and `TEMPLATE_TYPE`. So it can't be nested

# Solution

Use jinja2 as additional template engine (run before old template engine)

```c.jinja2
    switch (X->dtype) {
        {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
        {% set exp_func = 'expf' if DTYPE == FLOAT32 else 'exp' %}
    case {{DTYPE}}: {
        {{TYPE}}* X_array = X->buffer;
        {{TYPE}}* Y_array = Y->buffer;

        for (int32_t i = 0; i < total; i++) {
            Y_array[i] = {{exp_func}}(X_array[i]);
        }
        break;
    }
        {% endfor %}
    default:
        connx_error("Exp: Datatype %d is not supported yet.\n", X->dtype);
        return CONNX_NOT_SUPPORTED_DATATYPE;
    }
```

## Pros
- Not messing with C preprocessors
- Can be nested (can use different varname on every block)

## Cons
- IDE is confusing with jinja2 template. (On vim: set ft=c.jinja2 to fix it)
- Can be messing with clang-format

# Progress

- [x] Compatibility with older templates
- [x] Fix clang-format malfunctioning 