### PR TITLE
Handle clang-format is not found

### DIFF
--- a/bin/check-clang-format
+++ b/bin/check-clang-format
@@ -2,10 +2,17 @@
 
 set -eo pipefail
 
+CLANG_FORMAT_CMD='clang-format-10'
+
+if ! type "$CLANG_FORMAT_CMD" &>/dev/null; then
+    echo "$CLANG_FORMAT_CMD not found"
+    exit 127
+fi
+
 files=$(find src include examples ports/linux/src -type f \( -name '*.c' -or -name '*.h' \))
 result=0
 for fname in $files; do
-    if ! diff --color -u "$fname" <(clang-format-10 "$fname"); then
+    if ! diff --color -u "$fname" <($CLANG_FORMAT_CMD "$fname"); then
         result=1
     fi
 done


### PR DESCRIPTION
If clang-format is not found, return 127(for command not found) and don't try diff