### PR TITLE
Fix transpose, Shape

### DIFF
--- a/src/connx.c
+++ b/src/connx.c
@@ -365,6 +365,9 @@ static int parse_Graph(connx_Graph* graph, char* text) {
             uint32_t type = next_integer(token);
 
             switch (type) {
+            case 0: // NULL
+                node->attributes[i] = NULL;
+                break;
             case 1: // FLOAT
                 node->attributes[i] = connx_alloc(sizeof(float32_t));
                 if (node->attributes[i] == NULL) {

--- a/src/opset/Shape.c
+++ b/src/opset/Shape.c
@@ -22,15 +22,10 @@ int Shape(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uin
           __attribute__((unused)) uint32_t input_count, uint32_t* inputs, __attribute__((unused)) void** attributes) {
     connx_Tensor* data = connx_Graph_get(graph, inputs[0]);
 
-    int32_t end = data->ndim;
-    int32_t start = 0;
+    // end is optional, start is optional with default value from onnx-connx
 
-    if (attributes[0] != NULL) {
-        end = *(int32_t*)attributes[0];
-    }
-    if (attributes[1] != NULL) {
-        start = *(int32_t*)attributes[1];
-    }
+    int32_t end = (attributes[0] == NULL) ? data->ndim : *(int32_t*)attributes[0];
+    int32_t start = *(int32_t*)attributes[1];
 
     // handle negative start and end
     if (end < 0) {

--- a/src/opset/Shape.c
+++ b/src/opset/Shape.c
@@ -22,8 +22,15 @@ int Shape(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uin
           __attribute__((unused)) uint32_t input_count, uint32_t* inputs, __attribute__((unused)) void** attributes) {
     connx_Tensor* data = connx_Graph_get(graph, inputs[0]);
 
-    int32_t end = *(int32_t*)attributes[0];
-    int32_t start = *(int32_t*)attributes[1];
+    int32_t end = data->ndim;
+    int32_t start = 0;
+
+    if (attributes[0] != NULL) {
+        end = *(int32_t*)attributes[0];
+    }
+    if (attributes[1] != NULL) {
+        start = *(int32_t*)attributes[1];
+    }
 
     // handle negative start and end
     if (end < 0) {
@@ -38,17 +45,17 @@ int Shape(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uin
     start = (start < 0) ? 0 : (start > data->ndim) ? data->ndim : start;
     end = (end < 0) ? 0 : (end > data->ndim) ? data->ndim : end;
 
-    int32_t shape_[1] = {end - start};
+    int32_t output_shape[1] = {end - start};
 
-    connx_Tensor* shape = connx_Tensor_alloc(INT64, 1, shape_);
+    connx_Tensor* shape = connx_Tensor_alloc(INT64, 1, output_shape);
     if (shape == NULL) {
         return CONNX_NOT_ENOUGH_MEMORY;
     }
 
     int64_t* array = shape->buffer;
 
-    for (int i = start; i < end; i++) {
-        array[i] = data->shape[i];
+    for (int i = 0; i < (end - start); i++) {
+        array[i] = data->shape[start + i];
     }
 
     connx_Graph_set(graph, outputs[0], shape);

--- a/src/opset/Transpose.c
+++ b/src/opset/Transpose.c
@@ -41,7 +41,9 @@ int Transpose(connx_Graph* graph, __attribute__((unused)) uint32_t output_count,
     int32_t output_ndim = data->ndim;
     int32_t output_shape[output_ndim];
 
-    if (perm_attr->count == 0) {
+    const bool is_default_perm = perm_attr->count == 0;
+
+    if (is_default_perm) {
         for (int32_t i = 0; i < output_ndim; i++) {
             output_shape[output_ndim - i - 1] = data->shape[i];
         }
@@ -75,11 +77,13 @@ int Transpose(connx_Graph* graph, __attribute__((unused)) uint32_t output_count,
 
     // If perm is like [1, 0, 2, 3], last [2, 3] part is treated as one big block;
     int32_t block_size = 1;
-    for (int32_t i = output_ndim - 1; i >= 0; i--) {
-        if (perm_attr->array[i] == i) {
-            block_size *= output_shape[i];
-        } else {
-            break;
+    if (!is_default_perm) {
+        for (int32_t i = output_ndim - 1; i >= 0; i--) {
+            if (perm_attr->array[i] == i) {
+                block_size *= output_shape[i];
+            } else {
+                break;
+            }
         }
     }
 

--- a/src/opset/Transpose.c
+++ b/src/opset/Transpose.c
@@ -78,6 +78,8 @@ int Transpose(connx_Graph* graph, __attribute__((unused)) uint32_t output_count,
     for (int32_t i = output_ndim - 1; i >= 0; i--) {
         if (perm_attr->array[i] == i) {
             block_size *= output_shape[i];
+        } else {
+            break;
         }
     }
 

--- a/test/data/node/test_shape/0.text
+++ b/test/data/node/test_shape/0.text
@@ -3,4 +3,4 @@ initializer 0
 output 1 2
 input 1 1
 node 1
-Shape 1 1 0 2 1
+Shape 1 1 2 2 1 3 end 0 5 start 2 0

--- a/test/data/node/test_shape_clip_end/0.text
+++ b/test/data/node/test_shape_clip_end/0.text
@@ -3,4 +3,4 @@ initializer 0
 output 1 2
 input 1 1
 node 1
-Shape 1 1 0 2 1
+Shape 1 1 2 2 1 3 end 2 10 5 start 2 0

--- a/test/data/node/test_shape_clip_start/0.text
+++ b/test/data/node/test_shape_clip_start/0.text
@@ -3,4 +3,4 @@ initializer 0
 output 1 2
 input 1 1
 node 1
-Shape 1 1 0 2 1
+Shape 1 1 2 2 1 3 end 0 5 start 2 -10

--- a/test/data/node/test_shape_end_1/0.text
+++ b/test/data/node/test_shape_end_1/0.text
@@ -3,4 +3,4 @@ initializer 0
 output 1 2
 input 1 1
 node 1
-Shape 1 1 0 2 1
+Shape 1 1 2 2 1 3 end 2 1 5 start 2 0

--- a/test/data/node/test_shape_end_negative_1/0.text
+++ b/test/data/node/test_shape_end_negative_1/0.text
@@ -3,4 +3,4 @@ initializer 0
 output 1 2
 input 1 1
 node 1
-Shape 1 1 0 2 1
+Shape 1 1 2 2 1 3 end 2 -1 5 start 2 0

--- a/test/data/node/test_shape_example/0.text
+++ b/test/data/node/test_shape_example/0.text
@@ -3,4 +3,4 @@ initializer 0
 output 1 2
 input 1 1
 node 1
-Shape 1 1 0 2 1
+Shape 1 1 2 2 1 3 end 0 5 start 2 0

--- a/test/data/node/test_shape_start_1/0.text
+++ b/test/data/node/test_shape_start_1/0.text
@@ -3,4 +3,4 @@ initializer 0
 output 1 2
 input 1 1
 node 1
-Shape 1 1 0 2 1
+Shape 1 1 2 2 1 3 end 0 5 start 2 1

--- a/test/data/node/test_shape_start_1_end_2/0.text
+++ b/test/data/node/test_shape_start_1_end_2/0.text
@@ -3,4 +3,4 @@ initializer 0
 output 1 2
 input 1 1
 node 1
-Shape 1 1 0 2 1
+Shape 1 1 2 2 1 3 end 2 2 5 start 2 1

--- a/test/data/node/test_shape_start_1_end_negative_1/0.text
+++ b/test/data/node/test_shape_start_1_end_negative_1/0.text
@@ -3,4 +3,4 @@ initializer 0
 output 1 2
 input 1 1
 node 1
-Shape 1 1 0 2 1
+Shape 1 1 2 2 1 3 end 2 -1 5 start 2 1

--- a/test/data/node/test_shape_start_negative_1/0.text
+++ b/test/data/node/test_shape_start_negative_1/0.text
@@ -3,4 +3,4 @@ initializer 0
 output 1 2
 input 1 1
 node 1
-Shape 1 1 0 2 1
+Shape 1 1 2 2 1 3 end 0 5 start 2 -1


### PR DESCRIPTION
## Transpose
Fix block based memcpy
If [0, 3, 1, 2, 4, 5], use [4, 5], Not [0, _, _, _, 4, 5]
Check if given perm is default (no array)

## Shape
index error, NULL check on attributes
Update test data with https://github.com/semihlab/onnx-connx/commit/7260ff597376b2fef4659ede5811a45836ee4ebb