### PR TITLE
Fix preprocessor

### DIFF
--- a/bin/gen.sh
+++ b/bin/gen.sh
@@ -134,7 +134,8 @@ for FILE in ${OPSET}; do
     if [[ ${IS_DUMP} == 1 ]]; then
         echo "opset/${FILE}.c"
     else
-        if [[ ${INPUT_DIR}/opset/${FILE}.c -nt ${OUTPUT_DIR}/opset/${FILE}.c ]]; then
+        if [[ ${INPUT_DIR}/opset/${FILE}.c -nt ${OUTPUT_DIR}/opset/${FILE}.c ]] || \
+            [[ ${HOME}/preprocessor.py -nt ${OUTPUT_DIR}/opset/${FILE}.c ]]; then
             echo "Preprocessing ${INPUT_DIR}/opset/${FILE}.c ${OUTPUT_DIR}/opset/${FILE}.c"
             ${HOME}/preprocessor.py ${INPUT_DIR}/opset/${FILE}.c ${OUTPUT_DIR}/opset/${FILE}.c
         fi

--- a/bin/preprocessor.py
+++ b/bin/preprocessor.py
@@ -148,19 +148,22 @@ consts = {
 }
 
 with open(output_source, 'w') as output:
+    buffer = io.StringIO()
     line_no = 1
-    output.write('#line {} "{}"\n'.format(line_no, input_source))
+    buffer.write('#line {} "{}"\n'.format(line_no, input_source))
 
-    with open(input_source, 'r') as input_orig:
-        input = io.StringIO(
-            jinja2.Template(input_orig.read()).render(
-                input_orig.read(),
-                **consts
-            )
-        )
+    jinja_start_tokens = ['{%', '{{']
+    jinja_end_tokens = ['%}', '}}']
+
+    with open(input_source, 'r') as input:
 
         line = input.readline()
         while line:
+            if any(token in line for token in jinja_end_tokens):
+                line += '#line {} "{}"\n'.format(line_no+1, input_source)
+            elif any(token in line for token in jinja_start_tokens):
+                buffer.write('#line {} "{}"\n'.format(line_no, input_source))
+
             if 'TEMPLATE_START(' in line:
                 # Parse _DTYPE and _TYPE
                 tokens = re.split(r',|\(|\)', line)
@@ -186,19 +189,25 @@ with open(output_source, 'w') as output:
                     type = get_TYPE(dtype)
                     name = get_NAME(dtype)
 
-                    output.write('#line {} "{}"\n'.format(line_no + 1, input_source))  # plus header
+                    buffer.write('#line {} "{}"\n'.format(line_no + 1, input_source))  # plus header
 
                     for idx, (line) in enumerate(template):
                         line = line.replace('TEMPLATE_DTYPE', 'CONNX_' + dtype)
                         line = line.replace('TEMPLATE_TYPE', type)
                         line = line.replace('TEMPLATE_NAME', name)
 
-                        output.write(line)
+                        buffer.write(line)
 
                 line = input.readline()
                 line_no += len(template) + 2  # lines of template + header + tail
             else:
-                output.write(line)
+                buffer.write(line)
 
                 line = input.readline()
                 line_no += 1
+
+    content = buffer.getvalue()
+    rendered = jinja2.Template(content).render(
+        **consts
+    )
+    output.write(rendered)

--- a/bin/preprocessor.py
+++ b/bin/preprocessor.py
@@ -152,8 +152,8 @@ with open(output_source, 'w') as output:
     line_no = 1
     buffer.write('#line {} "{}"\n'.format(line_no, input_source))
 
-    jinja_start_tokens = ['{%', '{{']
-    jinja_end_tokens = ['%}', '}}']
+    jinja_start_tokens = ['{%', '{{', '{#']
+    jinja_end_tokens = ['%}', '}}', '#}']
 
     with open(input_source, 'r') as input:
 

--- a/ports/linux/CMakeLists.txt
+++ b/ports/linux/CMakeLists.txt
@@ -37,6 +37,8 @@ add_custom_command(
     COMMAND ../../bin/gen.sh -o ${CMAKE_CURRENT_BINARY_DIR}/src
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${CONNX_SRC} ${CONNX_HDR} ${HAL_SRC} ${OPSET}
+    ../../bin/gen.sh
+    ../../bin/preprocessor.py
     COMMENT "Generating source code"
 )
 


### PR DESCRIPTION
- Rerun proprocessor if `preprocessor.py` changed
- Rerun `gen.sh` if `gen.sh` changed
- Mark `#line {lineno} {filename}` for jinja2 template

Fixed preprocessor with jinja2 engine generates like this:
```C
// {% set dtype = 'int32' %}
int data_size = sizeof({{
        (dtype + 
         '_t')
        }});

switch (data_size) {
// {% for size in (1, 2,) %}
case {{ size }}:
    printf("data_size: %d", {{size}})
    break;
// {% endfor %}
default:
    printf("data_size: %s", "unknown")
    break;
}
```

```C
#line 1 "/home/jarm/workspace/connx/src/opset/test.c"
// 
#line 2 "/home/jarm/workspace/connx/src/opset/test.c"
#line 2 "/home/jarm/workspace/connx/src/opset/test.c"
int data_size = sizeof(int32_t);
#line 6 "/home/jarm/workspace/connx/src/opset/test.c"

switch (data_size) {
// 
#line 9 "/home/jarm/workspace/connx/src/opset/test.c"
case 1:
#line 10 "/home/jarm/workspace/connx/src/opset/test.c"
    printf("data_size: %d", 1)
#line 11 "/home/jarm/workspace/connx/src/opset/test.c"
    break;
// 
#line 9 "/home/jarm/workspace/connx/src/opset/test.c"
case 2:
#line 10 "/home/jarm/workspace/connx/src/opset/test.c"
    printf("data_size: %d", 2)
#line 11 "/home/jarm/workspace/connx/src/opset/test.c"
    break;
// 
#line 13 "/home/jarm/workspace/connx/src/opset/test.c"
default:
    printf("data_size: %s", "unknown")
    break;
}

```