### PR TITLE
Change jinja2 block token

### DIFF
--- a/src/opset/Cast.c
+++ b/src/opset/Cast.c
@@ -40,41 +40,41 @@ int Cast(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint
     int32_t total = connx_Int32_product(input->ndim, input->shape);
 
     switch (to) {
-    /* {% for DTYPE_output, TYPE_output in loop_types(FLOAT32, FLOAT64, INT8, INT16, INT32, INT64, UINT8, UINT16,
-     UINT32, UINT64, BOOL, STRING) %} */
+    /*{% for DTYPE_output, TYPE_output in loop_types(FLOAT32, FLOAT64, INT8, INT16, INT32, INT64, UINT8, UINT16,
+     UINT32, UINT64, BOOL, STRING) %}*/
     case {{ DTYPE_output }}: {
         {{TYPE_output}}* output_array = output->buffer;
 
         switch (input->dtype) {
-            /* {% for DTYPE_input, TYPE_input in loop_types(FLOAT32, FLOAT64, INT8, INT16, INT32, INT64, UINT8, UINT16,
-             UINT32, UINT64, BOOL, STRING) %} */
+            /*{% for DTYPE_input, TYPE_input in loop_types(FLOAT32, FLOAT64, INT8, INT16, INT32, INT64, UINT8, UINT16,
+             UINT32, UINT64, BOOL, STRING) %}*/
         case {{ DTYPE_input }}: {
             {{TYPE_input}}* input_array = input->buffer;
 
             for (int32_t i = 0; i < total; i++) {
-                // {% if DTYPE_output == STRING and DTYPE_input == STRING %}
+                /*{% if DTYPE_output == STRING and DTYPE_input == STRING %}*/
                 strcpy(output_array[i], input_array[i]); // FIXME: strncpy?
-                // {% elif DTYPE_output == STRING %}
-                // {%   if DTYPE_input in (FLOAT32, FLOAT64) %}
+                /*{% elif DTYPE_output == STRING %}*/
+                /*{%   if DTYPE_input in (FLOAT32, FLOAT64) %}*/
                 sprintf(output_array[i], "%g", input_array[i]); // FIXME: float to string
-                // {%   elif DTYPE_input in (INT64, UINT64) %}
+                /*{%   elif DTYPE_input in (INT64, UINT64) %}*/
                 sprintf(output_array[i], "%ld", input_array[i]);
-                // {%   else %}
+                /*{%   else %}*/
                 sprintf(output_array[i], "%d", input_array[i]);
-                // {%   endif %}
-                // {% elif DTYPE_input == STRING %}
-                // {%   if DTYPE_output in (FLOAT32, FLOAT64) %}
+                /*{%   endif %}*/
+                /*{% elif DTYPE_input == STRING %}*/
+                /*{%   if DTYPE_output in (FLOAT32, FLOAT64) %}*/
                 output_array[i] = atof(input_array[i]); // FIXME: string to float
-                // {%   else %}
+                /*{%   else %}*/
                 output_array[i] = atoi(input_array[i]);
-                // {%   endif %}
-                // {% else %}
+                /*{%   endif %}*/
+                /*{% else %}*/
                 output_array[i] = input_array[i];
-                // {% endif %}
+                /*{% endif %}*/
             }
             break;
         }
-            // {% endfor %}  // DTYPE_input, TYPE_input
+            /*{% endfor %}*/ // DTYPE_input, TYPE_input
         default:
             connx_error("Cast: Datatype %d on input is not supported yet.\n", input->dtype);
             return CONNX_NOT_SUPPORTED_DATATYPE;
@@ -82,7 +82,7 @@ int Cast(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint
 
         break;
     }
-        // {% endfor %}  // DTYPE_output, TYPE_output
+        /*{% endfor %}*/ // DTYPE_output, TYPE_output
     default:
         connx_error("Cast: Datatype %d on output is not supported yet.\n", output->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Concat.c
+++ b/src/opset/Concat.c
@@ -63,12 +63,12 @@
 
 int Concat(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
            __attribute__((unused)) uint32_t input_count, uint32_t* inputs_, __attribute__((unused)) void** attributes) {
-    /* {% set SUPPORTED_DTYPES = [
+    /*{% set SUPPORTED_DTYPES = [
        UINT8, UINT16, UINT32, UINT64,
        INT8, INT16, INT32, INT64,
        FLOAT32, FLOAT64,
        BOOL,
-    ] %} */
+    ] %}*/
     /*
         TODO: Should support these attributes:
         STRING,
@@ -127,7 +127,7 @@ int Concat(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, ui
     memset(input_offsets, 0, sizeof(uint32_t) * input_count);
 
     switch (inputs[0]->dtype) {
-        // {% for DTYPE, TYPE in loop_types(*SUPPORTED_DTYPES) %}
+        /*{% for DTYPE, TYPE in loop_types(*SUPPORTED_DTYPES) %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* output_array = concat_result->buffer;
 
@@ -159,7 +159,7 @@ int Concat(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, ui
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Concat: Datatype %d is not supported yet.\n", inputs[0]->dtype);
         connx_free(concat_result);

--- a/src/opset/Cos.c
+++ b/src/opset/Cos.c
@@ -31,8 +31,8 @@ int Cos(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        // {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
-        // {% set cos_func = 'cosf' if DTYPE == FLOAT32 else 'cos' %}
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+        /*{% set cos_func = 'cosf' if DTYPE == FLOAT32 else 'cos' %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
@@ -42,7 +42,7 @@ int Cos(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Cos: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Cosh.c
+++ b/src/opset/Cosh.c
@@ -31,8 +31,8 @@ int Cosh(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        // {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
-        // {% set cosh_func = 'coshf' if DTYPE == FLOAT32 else 'cosh' %}
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+        /*{% set cosh_func = 'coshf' if DTYPE == FLOAT32 else 'cosh' %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
@@ -42,7 +42,7 @@ int Cosh(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Cosh: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Exp.c
+++ b/src/opset/Exp.c
@@ -31,8 +31,8 @@ int Exp(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        // {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
-        // {% set exp_func = 'expf' if DTYPE == FLOAT32 else 'exp' %}
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+        /*{% set exp_func = 'expf' if DTYPE == FLOAT32 else 'exp' %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
@@ -42,7 +42,7 @@ int Exp(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Exp: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Gather.c
+++ b/src/opset/Gather.c
@@ -22,24 +22,22 @@
 
 int Gather(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
            __attribute__((unused)) uint32_t input_count, uint32_t* inputs, __attribute__((unused)) void** attributes) {
-    /*
-        {% set supported_dtypes = [
-            UINT8,
-            UINT16,
-            UINT32,
-            UINT64,
-            INT8,
-            INT16,
-            INT32,
-            INT64,
-            FLOAT32,
-            FLOAT64,
-            BOOL,
-        ]
-        %}
-        TODO:
-        STRING,
-    */
+    /*{% set supported_dtypes = [
+        UINT8,
+        UINT16,
+        UINT32,
+        UINT64,
+        INT8,
+        INT16,
+        INT32,
+        INT64,
+        FLOAT32,
+        FLOAT64,
+        BOOL,
+    ]
+    %}*/
+    // TODO: STRING,
+
     // inputs
     connx_Tensor* data = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* indices = connx_Graph_get(graph, inputs[1]);
@@ -82,12 +80,12 @@ int Gather(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, ui
 
     // get datatype size
     switch (data->dtype) {
-        // {% for DTYPE, TYPE in loop_types(*supported_dtypes) %}
+        /*{% for DTYPE, TYPE in loop_types(*supported_dtypes) %}*/
     case {{ DTYPE }}: {
         datatype_size = sizeof({{TYPE}});
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Concat: Datatype %d is not supported yet.\n", data->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;
@@ -95,7 +93,7 @@ int Gather(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, ui
 
     // do gather
     switch (indices->dtype) {
-        // {% for DTYPE, TYPE in loop_types(INT32, INT64) %}
+        /*{% for DTYPE, TYPE in loop_types(INT32, INT64) %}*/
     case {{ DTYPE }}: {
         // outer = data[0:axis]
         int32_t outer_loop_count = connx_Int32_product(axis, data->shape);
@@ -141,7 +139,7 @@ int Gather(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, ui
 
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Gather: Datatype %d is not supported yet.\n", indices->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/LeakyRelu.c
+++ b/src/opset/LeakyRelu.c
@@ -31,7 +31,7 @@ int LeakyRelu(connx_Graph* graph, __attribute__((unused)) uint32_t output_count,
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        // {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
@@ -41,7 +41,7 @@ int LeakyRelu(connx_Graph* graph, __attribute__((unused)) uint32_t output_count,
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("LeakyRelu: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Log.c
+++ b/src/opset/Log.c
@@ -31,8 +31,8 @@ int Log(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        // {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
-        // {% set log_func = 'logf' if DTYPE == FLOAT32 else 'log' %}
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+        /*{% set log_func = 'logf' if DTYPE == FLOAT32 else 'log' %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
@@ -42,7 +42,7 @@ int Log(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Log: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Sigmoid.c
+++ b/src/opset/Sigmoid.c
@@ -31,8 +31,8 @@ int Sigmoid(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, u
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        // {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
-        // {% set exp_func = 'expf' if DTYPE == FLOAT32 else 'exp' %}
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+        /*{% set exp_func = 'expf' if DTYPE == FLOAT32 else 'exp' %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
@@ -42,7 +42,7 @@ int Sigmoid(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, u
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Sigmoid: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Sign.c
+++ b/src/opset/Sign.c
@@ -29,8 +29,8 @@ int Sign(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        /* {% for DTYPE, TYPE in loop_types(UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64, FLOAT32, FLOAT64)
-         %} */
+        /*{% for DTYPE, TYPE in loop_types(UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64, FLOAT32, FLOAT64)
+        %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
@@ -40,7 +40,7 @@ int Sign(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Sign: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Sin.c
+++ b/src/opset/Sin.c
@@ -31,8 +31,8 @@ int Sin(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        // {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
-        // {% set sin_func = 'sinf' if DTYPE == FLOAT32 else 'sin' %}
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+        /*{% set sin_func = 'sinf' if DTYPE == FLOAT32 else 'sin' %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
@@ -42,7 +42,7 @@ int Sin(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Sin: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Sinh.c
+++ b/src/opset/Sinh.c
@@ -31,8 +31,8 @@ int Sinh(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        // {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
-        // {% set sinh_func = 'sinhf' if DTYPE == FLOAT32 else 'sinh' %}
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+        /*{% set sinh_func = 'sinhf' if DTYPE == FLOAT32 else 'sinh' %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
@@ -42,7 +42,7 @@ int Sinh(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Sinh: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Slice.c
+++ b/src/opset/Slice.c
@@ -30,16 +30,15 @@ int32_t get_input_index(const int32_t ndim, const int32_t* input_shape, const in
 
 int Slice(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
           __attribute__((unused)) uint32_t input_count, uint32_t* inputs, __attribute__((unused)) void** attributes) {
-    /* {% set supported_data_types = [
+    /*{% set supported_data_types = [
         INT8, INT16, INT32, INT64,
         UINT8, UINT16, UINT32, UINT64,
         FLOAT32, FLOAT64,
         BOOL,
-        ] %}
-        TODO: STRING
+        ] %}*/
+    // TODO: STRING
 
-        {% set supported_index_types = [ INT32, INT64, ] %}
-     */
+    /*{% set supported_index_types = [ INT32, INT64, ] %}*/
     connx_Tensor* data = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* starts = connx_Graph_get(graph, inputs[1]);
     connx_Tensor* ends = connx_Graph_get(graph, inputs[2]);
@@ -63,7 +62,7 @@ int Slice(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uin
     }
 
     switch (starts->dtype) {
-        // {% for DTYPE, TYPE in loop_types(*supported_index_types) %}
+        /*{% for DTYPE, TYPE in loop_types(*supported_index_types) %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* starts_array = starts->buffer;
         {{TYPE}}* ends_array = ends->buffer;
@@ -113,7 +112,7 @@ int Slice(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uin
 
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Unsupported index type: %d", starts->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;
@@ -131,9 +130,9 @@ int Slice(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uin
     size_t data_type_size;
 
     switch (data->dtype) {
-        // {% for dtype in supported_data_types %}
+        /*{% for dtype in supported_data_types %}*/
     case {{ dtype }}:
-        // {% endfor %}
+        /*{% endfor %}*/
         {
             data_type_size = connx_DataType_size(data->dtype);
             break;

--- a/src/opset/Split.c
+++ b/src/opset/Split.c
@@ -22,16 +22,15 @@
 
 int Split(connx_Graph* graph, uint32_t output_count, uint32_t* outputs_, uint32_t input_count, uint32_t* inputs,
           void** attributes) {
-    /* {% set supported_data_types = [
+    /*{% set supported_data_types = [
         INT8, INT16, INT32, INT64,
         UINT8, UINT16, UINT32, UINT64,
         FLOAT32, FLOAT64,
         BOOL,
-        ] %}
-        TODO: STRING
+        ] %}*/
+    // TODO: STRING
 
-        {% set supported_index_types = [ INT32, INT64, ] %}
-     */
+    /*{% set supported_index_types = [ INT32, INT64, ] %}*/
     connx_Tensor* input = connx_Graph_get(graph, inputs[0]);
     // connx_Tensor* split = connx_Graph_get(graph, inputs[1]); // Use it later
     int64_t split[output_count];
@@ -76,9 +75,9 @@ int Split(connx_Graph* graph, uint32_t output_count, uint32_t* outputs_, uint32_
     size_t data_type_size;
 
     switch (input->dtype) {
-        // {% for dtype in supported_data_types %}
+        /*{% for dtype in supported_data_types %}*/
     case {{ dtype }}:
-        // {% endfor %}
+        /*{% endfor %}*/
         {
             data_type_size = connx_DataType_size(input->dtype);
             break;

--- a/src/opset/Tan.c
+++ b/src/opset/Tan.c
@@ -31,8 +31,8 @@ int Tan(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        // {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
-        // {% set tan_func = 'tanf' if DTYPE == FLOAT32 else 'tan' %}
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+        /*{% set tan_func = 'tanf' if DTYPE == FLOAT32 else 'tan' %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
@@ -42,7 +42,7 @@ int Tan(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint3
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Tan: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Tanh.c
+++ b/src/opset/Tanh.c
@@ -31,8 +31,8 @@ int Tanh(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        // {% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}
-        // {% set tanh_func = 'tanhf' if DTYPE == FLOAT32 else 'tanh' %}
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+        /*{% set tanh_func = 'tanhf' if DTYPE == FLOAT32 else 'tanh' %}*/
     case {{ DTYPE }}: {
         {{TYPE}}* X_array = X->buffer;
         {{TYPE}}* Y_array = Y->buffer;
@@ -42,7 +42,7 @@ int Tanh(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint
         }
         break;
     }
-        // {% endfor %}
+        /*{% endfor %}*/
     default:
         connx_error("Tanh: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Transpose.c
+++ b/src/opset/Transpose.c
@@ -26,14 +26,13 @@ int32_t get_output_index(const int32_t ndim, const int32_t* input_shape, const i
 int Transpose(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
               __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
               __attribute__((unused)) void** attributes) {
-    /* {% set supported_data_types = [
+    /*{% set supported_data_types = [
         INT8, INT16, INT32, INT64,
         UINT8, UINT16, UINT32, UINT64,
         FLOAT32, FLOAT64,
         BOOL,
-        ] %}
-        TODO: STRING
-     */
+        ] %}*/
+    // TODO: STRING
     connx_Tensor* data = connx_Graph_get(graph, inputs[0]);
 
     connx_AttributeInts* perm_attr = attributes[0];
@@ -56,9 +55,9 @@ int Transpose(connx_Graph* graph, __attribute__((unused)) uint32_t output_count,
     size_t data_type_size;
 
     switch (data->dtype) {
-        // {% for dtype in supported_data_types %}
+        /*{% for dtype in supported_data_types %}*/
     case {{ dtype }}:
-        // {% endfor %}
+        /*{% endfor %}*/
         {
             data_type_size = connx_DataType_size(data->dtype);
             break;


### PR DESCRIPTION
## Before
token was `{%` and `%}` and use C comment string(`//` or `/* */`) to avoid clang-format error
But, this method leaves C comment string as there, And it causes these problems:

### Preprocessor `#line` is commented
```c
/* {% set x = 'x' %}
   {{ x * 4 }}
*/
```

Rendered like this:
```c
#line 1
/*
#line 2
#line 2
xxxx
#line 3
*/
```

You can see that `#line2`, `#line 3` is commented out (It's not working)

## After

Use `/*{%`, `%}*/` as Jinja2 token.

We could use `/*%`, `%*/` or something interpreted as C comment string, But `{%` part makes well-known editors detect it as Jinja2 template without special config

```c
/*{% 
set x = 'x'
 %}*/
some_state;
```

Rendered like this:
```c
#line 1
#line 4
some_state;
```

Much cleaner and `#line` preprocessor is working

But! this is MAY NOT working as purposed because generated preprocessor is in the comment block
```c
/*
some normal comment
{%
set x = 'x'
%}
some normal comment again
*/
```

## Remaining works:

### Variable block to prevent clang-format error
eg: `{{TYPE}}* array;`

I added `pointer` filter to possibly avoid this.

```c
{{TYPE}}* array; // Before
({{TYPE | pointer}}) array; // After
```